### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/repolinter.yml
+++ b/.github/workflows/repolinter.yml
@@ -8,6 +8,9 @@ name: Repolinter Action
 # filtered in the "Test Default Branch" step.
 on: [push, workflow_dispatch]
 
+permissions:
+  contents: read
+
 jobs:
   repolint:
     name: Run Repolinter


### PR DESCRIPTION
Potential fix for [https://github.com/newrelic/newrelic-ios-agent-spm/security/code-scanning/1](https://github.com/newrelic/newrelic-ios-agent-spm/security/code-scanning/1)

Add an explicit `permissions` block in `.github/workflows/repolinter.yml` at the workflow root (right after `on:` is the cleanest placement), setting least privilege needed for all jobs.  
For this workflow, a safe minimal baseline is:

- `contents: read` (required for checkout/repo reads)
  
No new imports, methods, or dependencies are needed since this is YAML configuration only. This preserves existing functionality while ensuring `GITHUB_TOKEN` is explicitly restricted.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
